### PR TITLE
day_of_week should be DAY_OF_WEEK

### DIFF
--- a/lib/nickel/query.rb
+++ b/lib/nickel/query.rb
@@ -1161,7 +1161,7 @@ module Nickel
         if self =~ /(start|through)\s+#{DATE_MM_SLASH_DD}/
           nsub!(/(?:\bon\s+)?(?:the\s+)?((?:(?:1st|2nd|3rd|4th|5th)\s+#{DAY_OF_WEEK_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})(?:of\s+)?(?:the)\s+month/) { |m1| "repeats monthly " + m1.gsub(/\b(and|the)\b/,'') }
         else
-          nsub!(/(?:\bon\s+)?(?:the\s+)?((?:(?:1st|2nd|3rd|4th|5th)\s+#{DAY_OF_WEEK_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})(?:of\s+)?(?:the)\s+month/) { |m1| m1.gsub(/\b(and|the)\b/,'').gsub(/#{day_of_week}/,'\1 this month') }
+          nsub!(/(?:\bon\s+)?(?:the\s+)?((?:(?:1st|2nd|3rd|4th|5th)\s+#{DAY_OF_WEEK_NB}\s+(?:and\s+)?(?:the\s+)?){1,10})(?:of\s+)?(?:the)\s+month/) { |m1| m1.gsub(/\b(and|the)\b/,'').gsub(/#{DAY_OF_WEEK}/,'\1 this month') }
         end
       end
 

--- a/spec/lib/nickel/nlp_spec.rb
+++ b/spec/lib/nickel/nlp_spec.rb
@@ -654,6 +654,19 @@ module Nickel
         end
       end
 
+      context "when the query is 'the last thursday of the month'" do
+        let(:query) { "the last thursday of the month" }
+        let(:run_date) { Time.local(2008, 8, 25) }
+
+        describe "#occurrences" do
+          it "is last thursday this month" do
+            expect(nlp.occurrences).to match_array [
+              Occurrence.new(type: :single, start_date: ZDate.new("20080828"))
+            ]
+          end
+        end
+      end
+
       context "when the query is 'third monday next month'" do
         let(:query) { "third monday next month" }
         let(:run_date) { Time.local(2008, 8, 25) }


### PR DESCRIPTION
A random test of 'the last thursday of the month' yieled an undefined variable. 

Quick fix, here you go.

```
  1) Nickel::NLP#parse when the query is 'the last thursday of the month' #occurrences is last thursday this month
     Failure/Error: let(:nlp) { NLP.new(query, run_date).tap(&:parse) }
     NameError:
       undefined local variable or method `day_of_week' for "the 5th thu of the month ":Nickel::NLPQuery
     # ./lib/nickel/query.rb:1164:in `block in standardize_input'
     # ./lib/nickel/query.rb:58:in `block in nsub!'
     # ./lib/nickel/query.rb:58:in `sub'
     # ./lib/nickel/query.rb:58:in `nsub!'
     # ./lib/nickel/query.rb:1164:in `standardize_input'
     # ./lib/nickel/query.rb:71:in `query_pre_processing'
     # ./lib/nickel/query.rb:20:in `standardize'
     # ./lib/nickel/nlp.rb:36:in `parse'
     # ./spec/lib/nickel/nlp_spec.rb:12:in `tap'
     # ./spec/lib/nickel/nlp_spec.rb:12:in `block (3 levels) in <module:Nickel>'
     # ./spec/lib/nickel/nlp_spec.rb:663:in `block (5 levels) in <module:Nickel>'
```
