### PR TITLE
Before and after should be private

### DIFF
--- a/lib/nickel/zdate.rb
+++ b/lib/nickel/zdate.rb
@@ -76,6 +76,8 @@ module Nickel
     end
 
     def <=>(d2)
+      return nil unless [:year, :month, :day].all?{|m| d2.respond_to?(m)}
+
       if before?(d2)
         -1
       elsif after?(d2)
@@ -545,15 +547,11 @@ module Nickel
     private
 
     def before?(d2)
-      d2.respond_to?(:year) && (year < d2.year) ||
-        d2.respond_to?(:month) && (year == d2.year && (month < d2.month ||
-          d2.respond_to?(:day) && (month == d2.month && day < d2.day)))
+      (year < d2.year) || (year == d2.year && (month < d2.month || (month == d2.month && day < d2.day)))
     end
 
     def after?(d2)
-      d2.respond_to?(:year) && (year > d2.year) ||
-        d2.respond_to?(:month) && (year == d2.year && (month > d2.month ||
-          d2.respond_to?(:day) && (month == d2.month && day > d2.day)))
+      (year > d2.year) || (year == d2.year && (month > d2.month || (month == d2.month && day > d2.day)))
     end
 
     def validate

--- a/lib/nickel/ztime.rb
+++ b/lib/nickel/ztime.rb
@@ -140,6 +140,8 @@ module Nickel
     end
 
     def <=>(t2)
+      return nil unless [:hour, :min, :sec].all?{|m| t2.respond_to?(m)}
+
       if before?(t2)
         -1
       elsif after?(t2)
@@ -340,15 +342,11 @@ module Nickel
     private
 
     def before?(t2)
-      (t2.respond_to? :hour) && (hour < t2.hour) ||
-        (t2.respond_to? :min) && (hour == t2.hour && (min < t2.min ||
-          (t2.respond_to? :sec) && (min == t2.min && sec < t2.sec)))
+      (hour < t2.hour) || (hour == t2.hour && (min < t2.min || (min == t2.min && sec < t2.sec)))
     end
 
     def after?(t2)
-      (t2.respond_to? :hour) && (hour > t2.hour) ||
-        (t2.respond_to? :min) && (hour == t2.hour && (min > t2.min ||
-          (t2.respond_to? :sec) && (min == t2.min && sec > t2.sec)))
+      (hour > t2.hour) || (hour == t2.hour && (min > t2.min || (min == t2.min && sec > t2.sec)))
     end
 
     def adjust_for(am_pm)

--- a/spec/lib/nickel/zdate_spec.rb
+++ b/spec/lib/nickel/zdate_spec.rb
@@ -89,6 +89,10 @@ module Nickel
       it "is false when the other object is a Date for any other day" do
         expect(d1).to_not eq Date.new(2010, 9, 27)
       end
+
+      it "is false when the other object is a String" do
+        expect(d1).to_not eq '20090927'
+      end
     end
   end
 end

--- a/spec/lib/nickel/ztime_spec.rb
+++ b/spec/lib/nickel/ztime_spec.rb
@@ -254,6 +254,10 @@ module Nickel
       it "is false when the other object is a Time for any other time" do
         expect(t1).to_not eq Time.parse("17:18:19")
       end
+
+      it "is false when the other object is a String" do
+        expect(t1).to_not eq "161718"
+      end
     end
 
     describe "#hour_str" do


### PR DESCRIPTION
The before and after methods in ZDate and ZTime should not be a part of the public interface - anyone relying on those methods should be using the standard < and > methods respectively. I've made those private to avoid confusion.

Also rolled in a bugfix for the == method (as provided by Comparable)
