### PR TITLE
handle case of specifying times without specifying dates

### DIFF
--- a/lib/nickel/construct_interpreter.rb
+++ b/lib/nickel/construct_interpreter.rb
@@ -25,6 +25,8 @@ module Nickel
         occurrences_from_recurrences_and_optional_date_span
       elsif found_wrappers_only
         occurrences_from_wrappers_only
+      elsif found_times
+        occurrences_from_times
       end
     end
 
@@ -243,10 +245,22 @@ module Nickel
       @dci.size > 0 && @dsci.size == 0 && @rci.size == 0
     end
 
+    def found_times
+      # One or more time constructs, NO date spans, NO recurrence,
+      # possible wrappers, possible time constructs, possible time spans
+      @tci.size > 0 && @dci.size == 0 && @dsci.size == 0 && @rci.size == 0
+    end
+
     def occurrences_from_dates
       @dci.each do |dindex|
         occ_base = Occurrence.new(type: :single, start_date: @constructs[dindex].date)
         create_occurrence_for_each_time_in_time_map(occ_base, dindex) { |occ| @occurrences << occ }
+      end
+    end
+
+    def occurrences_from_times
+      @tci.each do |index|
+        @occurrences << Occurrence.new(type: :single, start_time: @constructs[index].time)
       end
     end
 

--- a/spec/lib/nickel_spec.rb
+++ b/spec/lib/nickel_spec.rb
@@ -28,6 +28,25 @@ describe Nickel do
       end
     end
 
+    context "when the query is 'Yes, I can play at 9am'" do
+      let(:query) { 'Yes, I can play at 9am' }
+      let(:run_date) { Time.local(2014, 2, 26) }
+
+      describe '#message' do
+        it "is 'yes I can play'" do
+          expect(n.message).to eq 'yes I can play'
+        end
+      end
+
+      describe '#occurrences' do
+        it 'is single at 9:00am on unspecified date' do
+          expect(n.occurrences).to match_array [
+            Nickel::Occurrence.new(type: :single, start_time: Nickel::ZTime.new('9'))
+          ]
+        end
+      end
+    end
+
     context "when the query is 'wake up everyday at 11am'" do
       let(:query) { 'wake up everyday at 11am' }
       let(:run_date) { Time.local(2014, 2, 26) }


### PR DESCRIPTION
Resolves #31 

Allows times to be mentioned without date specifiers.  Occurrences are returned without start/end dates.  The developer is left to decide in application if context should be "today"